### PR TITLE
RHS Compat removed since it caused issues

### DIFF
--- a/Vindicta.Altis/Templates/Factions/3CB_BAF.sqf
+++ b/Vindicta.Altis/Templates/Factions/3CB_BAF.sqf
@@ -14,10 +14,8 @@ _array set [T_REQUIRED_ADDONS, [
 	"uk3cb_baf_units_mtp",	// BAF Units
 	"uk3cb_baf_equipment",	// BAF Equipment
 	"uk3cb_baf_units_ace",	// BAF Ace Compat
-	"uk3cb_baf_units_rhs",	// BAF RHS Compat
 	"uk3cb_baf_vehicles_MAN", // BAF Vehicles
 	"uk3cb_baf_weapons_L110", // BAF Weaponry
-	"uk3cb_baf_weapons_ace" // BAF RHS Ammo Compat	
 ]];
 
 //==== Infantry ====


### PR DESCRIPTION
Leaving this in will cause an error to pop up, ultimately making it unable for a server to start properly, I also have enough reason to believe that the compat addon is not required.